### PR TITLE
Replace usage of rcube_label with rcmail::get_instance()->gettext

### DIFF
--- a/chbox.php
+++ b/chbox.php
@@ -52,20 +52,20 @@ class chbox extends rcube_plugin {
     if ($skin == 'classic' or $skin == 'default') {
       $out .= "<div id=\"selectmenu\" class=\"popupmenu\">
         <ul>
-          <li><a title=\"".rcube_label('all')."\" href=\"#\" onclick=\"return rcmail.command('select-all','',this)\" class=\"active\">".rcube_label('all')."</a></li>
-          <li><a title=\"".rcube_label('currpage')."\" href=\"#\" onclick=\"return rcmail.command('select-all','page',this)\" class=\"active\">".rcube_label('currpage')."</a></li>
-          <li><a title=\"".rcube_label('unread')."\" href=\"#\" onclick=\"return rcmail.command('select-all','unread',this)\" class=\"active\">".rcube_label('unread')."</a></li>
-          <li><a title=\"".rcube_label('invert')."\" href=\"#\" onclick=\"return rcmail.command('select-all','invert',this)\" class=\"active\">".rcube_label('invert')."</a></li>
-          <li><a title=\"".rcube_label('none')."\" href=\"#\" onclick=\"return rcmail.command('select-none','',this)\" class=\"active\">".rcube_label('none')."</a></li>
+          <li><a title=\"".rcmail::get_instance()->gettext('all')."\" href=\"#\" onclick=\"return rcmail.command('select-all','',this)\" class=\"active\">".rcmail::get_instance()->gettext('all')."</a></li>
+          <li><a title=\"".rcmail::get_instance()->gettext('currpage')."\" href=\"#\" onclick=\"return rcmail.command('select-all','page',this)\" class=\"active\">".rcmail::get_instance()->gettext('currpage')."</a></li>
+          <li><a title=\"".rcmail::get_instance()->gettext('unread')."\" href=\"#\" onclick=\"return rcmail.command('select-all','unread',this)\" class=\"active\">".rcmail::get_instance()->gettext('unread')."</a></li>
+          <li><a title=\"".rcmail::get_instance()->gettext('invert')."\" href=\"#\" onclick=\"return rcmail.command('select-all','invert',this)\" class=\"active\">".rcmail::get_instance()->gettext('invert')."</a></li>
+          <li><a title=\"".rcmail::get_instance()->gettext('none')."\" href=\"#\" onclick=\"return rcmail.command('select-none','',this)\" class=\"active\">".rcmail::get_instance()->gettext('none')."</a></li>
         </ul>";
     } else {
       $out .="<div id=\"selectmenu\" class=\"popupmenu dropdown\">
         <ul>
-          <li title=\"".rcube_label('all')."\" onclick=\"return rcmail.command('select-all','',this)\" class=\"active\">".rcube_label('all')."</li>
-          <li title=\"".rcube_label('currpage')."\" onclick=\"return rcmail.command('select-all','page',this)\" class=\"active\">".rcube_label('currpage')."</li>
-          <li title=\"".rcube_label('unread')."\" onclick=\"return rcmail.command('select-all','unread',this)\" class=\"active\">".rcube_label('unread')."</li>
-          <li title=\"".rcube_label('invert')."\" onclick=\"return rcmail.command('select-all','invert',this)\" class=\"active\">".rcube_label('invert')."</li>
-          <li title=\"".rcube_label('none')."\" onclick=\"return rcmail.command('select-none','',this)\" class=\"active\">".rcube_label('none')."</li>
+          <li title=\"".rcmail::get_instance()->gettext('all')."\" onclick=\"return rcmail.command('select-all','',this)\" class=\"active\">".rcmail::get_instance()->gettext('all')."</li>
+          <li title=\"".rcmail::get_instance()->gettext('currpage')."\" onclick=\"return rcmail.command('select-all','page',this)\" class=\"active\">".rcmail::get_instance()->gettext('currpage')."</li>
+          <li title=\"".rcmail::get_instance()->gettext('unread')."\" onclick=\"return rcmail.command('select-all','unread',this)\" class=\"active\">".rcmail::get_instance()->gettext('unread')."</li>
+          <li title=\"".rcmail::get_instance()->gettext('invert')."\" onclick=\"return rcmail.command('select-all','invert',this)\" class=\"active\">".rcmail::get_instance()->gettext('invert')."</li>
+          <li title=\"".rcmail::get_instance()->gettext('none')."\" onclick=\"return rcmail.command('select-none','',this)\" class=\"active\">".rcmail::get_instance()->gettext('none')."</li>
         </ul>";
     }
     $out .= "</div>";


### PR DESCRIPTION
Roundcube deprecated rcube_label in version 1.2, so usage of that function results in warnings in Roundcube's log file (as per https://github.com/roundcube/roundcubemail/blob/release-1.2/program/include/bc.php#L44)

The fix is to use the function that rcube_label now calls internally. The "new" function has been available since 1.0, so this change should maintain compatibility with older versions.