### PR TITLE
Fix a bug which caused chbox breaking after checking or unchecking th…

### DIFF
--- a/chbox.js
+++ b/chbox.js
@@ -101,7 +101,7 @@ if (window.rcmail) {
 
 $(document).ready(function(){
   chbox_menu();
-  var li = '<label><input type="checkbox" name="list_col[]" value="chbox" id="cols_chbox" /> <span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
+    var li = '<label class="disabled"><input type="checkbox" name="list_col[]" value="chbox" name="cols_chbox" checked="checked" disabled="disabled" type="checkbox"/><span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
   $("#listmenu fieldset ul input#cols_threads").parent().after(li);
   $("#listoptions fieldset ul.proplist:first li:first-child").after('<li>'+li+'</li>');
 });


### PR DESCRIPTION
Fix a bug which caused the chbox breaking and checkbox disappeared after checking or unchecking the file "selector" in mails display order and applying the display preferences