### PR TITLE
improved compatibility for larry skin

### DIFF
--- a/skins/larry/chbox.css
+++ b/skins/larry/chbox.css
@@ -23,3 +23,8 @@
 {
    background-color: #0186ba;
 }
+
+.records-table tbody .chbox
+{
+   text-overflow: clip;
+}


### PR DESCRIPTION
fix a bug which display an ellipsis instead of checkbox when using larry skin on Firefox and safari (and some others browsers).
Tested on FF, Edge, google chrome and safari, with larry skins and its forks (Mabola, chameleon, etc) with roundcube 1.1.5