### PR TITLE
Separates chbox_menu and list options into skin specific JS

### DIFF
--- a/chbox.js
+++ b/chbox.js
@@ -40,11 +40,6 @@ function rcmail_selectmenu() {
   return false;
 }
 
-function chbox_menu(){
-  var link_html = '<a href="#" onclick="return rcmail.command(\'plugin.chbox.selectmenu\')">'+rcmail.env.chboxicon;
-  $('#rcmchbox').html(link_html);
-}
-
 if (window.rcmail) {
   rcmail.addEventListener('init', function(evt) {
     rcmail.register_command('plugin.chbox.selectmenu', rcmail_selectmenu, true);
@@ -98,10 +93,3 @@ if (window.rcmail) {
   });
 }
 
-
-$(document).ready(function(){
-  chbox_menu();
-    var li = '<label class="disabled"><input type="checkbox" name="list_col[]" value="chbox" name="cols_chbox" checked="checked" disabled="disabled" type="checkbox"/><span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
-  $("#listmenu fieldset ul input#cols_threads").parent().after(li);
-  $("#listoptions fieldset ul.proplist:first li:first-child").after('<li>'+li+'</li>');
-});

--- a/chbox.php
+++ b/chbox.php
@@ -29,6 +29,7 @@ class chbox extends rcube_plugin {
     $rcmail->output->add_label('chbox.chbox');
     $rcmail->output->set_env('chboxicon', $chboxicon);
     $this->include_stylesheet($this->local_skin_path(). '/chbox.css');
+    $this->include_script($this->local_skin_path(). '/chbox.js');
 
     return $args;
   }

--- a/skins/classic/chbox.js
+++ b/skins/classic/chbox.js
@@ -1,0 +1,11 @@
+
+function chbox_menu(){
+  var link_html = '<a href="#" onclick="return rcmail.command(\'plugin.chbox.selectmenu\')">'+rcmail.env.chboxicon;
+  $('#rcmchbox').html(link_html);
+}
+
+$(document).ready(function(){
+  chbox_menu();
+    var li = '<label class="disabled"><input type="checkbox" name="list_col[]" value="chbox" id="cols_chbox" checked="checked" disabled="disabled" type="checkbox"/><span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
+  $("#listmenu fieldset#listoptions-columns ul li:first-child").after('<li>'+li+'</li>');
+});

--- a/skins/larry/chbox.js
+++ b/skins/larry/chbox.js
@@ -1,0 +1,11 @@
+
+function chbox_menu(){
+  var link_html = '<a href="#" onclick="return rcmail.command(\'plugin.chbox.selectmenu\')">'+rcmail.env.chboxicon;
+  $('#rcmchbox').html(link_html);
+}
+
+$(document).ready(function(){
+  chbox_menu();
+    var li = '<label class="disabled"><input type="checkbox" name="list_col[]" value="chbox" name="cols_chbox" checked="checked" disabled="disabled" type="checkbox"/><span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
+  $("#listoptions fieldset#listoptions-columns ul.proplist:first li:first-child").after('<li>'+li+'</li>');
+});

--- a/skins/litecube-f/chbox.js
+++ b/skins/litecube-f/chbox.js
@@ -1,0 +1,11 @@
+function chbox_menu(){
+  var link_html = '<a href="#" onclick="return rcmail.command(\'plugin.chbox.selectmenu\')">'+rcmail.env.chboxicon;
+  $('#rcmchbox').html(link_html);
+}
+
+$(document).ready(function(){
+  chbox_menu();
+    var li = '<label class="disabled"><input type="checkbox" name="list_col[]" value="chbox" name="cols_chbox" checked="checked" disabled="disabled" type="checkbox"/><span>'+rcmail.get_label('chbox.chbox')+'</span></label>';
+  $("#listmenu fieldset ul input#cols_threads").parent().after(li);
+  $("#listoptions fieldset ul.proplist:first li:first-child").after('<li>'+li+'</li>');
+});


### PR DESCRIPTION
Works with RC 1.3.3 and last version of Larry
Separates chbox logic from presentation creating a skin specific JS to control how list options and menu are displayed on each skin

This helped us to control the list options menu in our skin without the need to hack chbox's core JS and fix an issue with RC-1.3.3 larry